### PR TITLE
Fix more floating point output bugs:

### DIFF
--- a/src/nautilus/doprnt.c
+++ b/src/nautilus/doprnt.c
@@ -530,17 +530,30 @@ void _doprnt (register const char * fmt,
 	        case 'F':
 	        case 'G':
 		    {
-			char buf[160];
+			char dbuf[160];
 			char *c;
-			int dec, sign;
-			int pos;
+			int numdigits, myprec;
+
+			// BOGUS stuff here, precision, etc, not handled to spec
 			
+			if (length != 0) {
+			    numdigits = length;
+			} else {
+			    numdigits = 6;
+			}
+
+			if (prec != -1) {
+			    myprec = prec;
+			} else {
+			    myprec = 6;
+			}
+
 			d = (double) va_arg(args, double);
+
 			
-			dtoa_printf_helper(d,*fmt,length,prec,buf,160);
+			dtoa_printf_helper(d,*fmt,numdigits,myprec,dbuf,160);
 			
-			c = buf;
-			(*putc)(putc_arg,'@');
+			c = dbuf;
 			while (*c) {
 			    (*putc)(putc_arg, *c++);
 			}

--- a/src/nautilus/dtoa.c
+++ b/src/nautilus/dtoa.c
@@ -6257,6 +6257,7 @@ int  dtoa_printf_helper(double x, char pf_type, int ndigits, int prec, char *buf
 
     if (s) {
 	*c++ = '-';
+	*c=0;
     }
 
     // handle special cases first

--- a/src/nautilus/printk.c
+++ b/src/nautilus/printk.c
@@ -1233,6 +1233,8 @@ int vsnprintf(char *buf, size_t size, const char *fmt, va_list args)
 		    char *c;
 		    int numdigits, prec;
 		    int k;
+
+		    // BOGUS stuff here, precision, etc, not handled to spec
 		    
 		    if (spec.precision != -1) {
 			numdigits = spec.precision;


### PR DESCRIPTION
 - make doprnt work identically to the printk engine
 - handle negative nan correctly / string bug

* **Please check if the request fulfills these requirements**
- [ ] The commit messages follow our guidelines (See [Contributing](https://github.com/HExSA-Lab/nautilus/blob/master/CONTRIBUTING.md)).
- [ ] The code follows our style guidelines, again see Contributing.
- [ ] If this is a new feature, changes to the core kernel have been minimized.
- [ ] If this feature doesn't touch the core kernel, has it been properly separated out in the `Kconfig`? and the source tree?
- [ ] If this pull request is for an open issue, the issue is properly referenced.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
